### PR TITLE
Add protoboard-6x4-breakout.jpg photo

### DIFF
--- a/gerber/README.md
+++ b/gerber/README.md
@@ -21,6 +21,8 @@ protoboard-6x4-breakout.zip
 * 4 adapters for TSSOP-14
 * 4 adapters for TSSOP-16
 
+<img src="https://github.com/electroniceel/protoboard/raw/master/photos/protoboard-6x4-breakout.jpg" width=400>
+
 protoboard-10x5.zip
 -------------------
 


### PR DESCRIPTION
The protoboard 6x4 with breakouts photo is in the repository, but was not embedded in the README :)